### PR TITLE
Add support for including specific locations and excluding specific devices

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -25,6 +25,26 @@
         "description": "How often to check LaCrossView API",
         "placeholder": "200"
       },
+      "devicesToExclude": {
+          "title": "Devices to Exclude (Name/ID)",
+          "description": "Add devices identifier (Name, ID from logs) to exclude from homebridge",
+          "type": "array",
+          "items": {
+            "title": "Device Name/ID",
+            "type": "string"
+          },
+          "default": []
+      },
+      "locationsToInclude": {
+          "title": "Device locations to include",
+          "description": "Device location IDs or names to include when discovering LaCrosseView devices (leave empty for all locations)",
+          "type": "array",
+          "items": {
+            "title": "Location Name/ID",
+            "type": "string"
+          },
+          "default": []
+      },
       "fakeGatoEnabled": {
         "title": "Enable FakeGato",
         "type": "boolean",
@@ -48,6 +68,22 @@
       "items": ["email", "password"]
     },
     "pollingInterval",
+    {
+      "key": "devicesToExclude",
+      "type": "array",
+      "buttonText": "Add Device",
+      "items": [
+        "devicesToExclude[]"
+      ]
+    },
+    {
+      "key": "locationsToInclude",
+      "type": "array",
+      "buttonText": "Add Location",
+      "items": [
+        "locationsToInclude[]"
+      ]
+    },
     {
       "type": "fieldset",
       "title": "Elgato Eve",

--- a/src/lacrosse.ts
+++ b/src/lacrosse.ts
@@ -136,15 +136,16 @@ export default class LaCrosseAPI {
     if (!locations) {
       locations = await this.getLocations()
     }
+
+    const result: Device[] = []
     for (const location of locations) {
       const url = LACROSSE_DEVICES_URL.replace('%ID%', location.id)
       const body: ResponseData<Device> = await fetch(url, undefined, this.token.value)
 
-      // TODO manage multiple locations ?
-      return body.items
+      result.push(...body.items)
     }
 
-    return []
+    return result
   }
 
   async getDeviceWeatherData(device: Device): Promise<DeviceWeatherData> {

--- a/src/lacrosse.ts
+++ b/src/lacrosse.ts
@@ -30,7 +30,7 @@ type ResponseLogin = {
   refreshToken: string
 }
 
-type Device = {
+export type Device = {
   id: string
   modifiedOn: Date
   name: string
@@ -49,8 +49,9 @@ type Sensor = {
   fields: [string]
 }
 
-type Location = {
+export type Location = {
   id: string
+  name: string
 }
 
 enum Unit {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -157,7 +157,11 @@ export class LaCrosseViewPlatform implements DynamicPlatformPlugin {
 
         if (initial || !existingAccessory) {
           this.log.info('New Device Online: [%s] sensor [%s]', device.name, device.id)
+          if (!existingAccessory) {
             this.log.info('Adding: [%s] sensor [%s]', device.name, device.id)
+          } else {
+            this.log.info('Updating: [%s] sensor [%s]', device.name, device.id)
+          }
         }
         if (existingAccessory) {
           // the accessory already exists


### PR DESCRIPTION
I've based the schema for this on the Sensibo plugin at https://github.com/nitaybz/homebridge-sensibo-ac/blob/master/config.schema.json

Now you can see locations in the logs and add specific locations to include, and the same with devices (except to exclude).