### PR TITLE
Add configuration to disable polling logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ It is recommended to use [Homebridge Config UI X](https://github.com/oznu/homebr
   "devicesToExclude": ["id-device"],
   "locationsToExclude": ["id-location"],
   "pollingInterval": 200,
-  "fakeGatoEnabled": false
+  "fakeGatoEnabled": false,
+  "disablePollingLogs": false
 }]
 ```
 
@@ -58,6 +59,7 @@ It is recommended to use [Homebridge Config UI X](https://github.com/oznu/homebr
 - `locationsToExclude`: Location ids to exclude _(Default to `[]`)_
 - `fakeGatoEnabled`: If historical data should be reported to the Elgato Eve App _(Default to `false`)_
 - `fakeGatoStoragePath`: Custom path where to save fakegato history _(Default to homebridge user path)_
+- `disablePollingLogs`: Disable polling status logs in homebridge _(Default to `false`)_
 
 > You can find device / location ids in your homebridge logs in [debug mode](https://github.com/homebridge/homebridge/wiki/Basic-Troubleshooting#debug-mode)
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -61,6 +61,12 @@
         "title": "FakeGato Storage Path",
         "type": "string",
         "description": "Specify a custom path to save FakeGato history."
+      },
+      "disablePollingLogs": {
+        "title": "Disable Polling Logs",
+        "type": "boolean",
+        "default": false,
+        "description": "Disable polling status logs in homebridge."
       }
     }
   },
@@ -92,7 +98,8 @@
           "type": "array",
           "buttonText": "Add Location",
           "items": ["locationsToExclude[]"]
-        }
+        },
+        "disablePollingLogs"
       ]
     },
     {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -125,7 +125,9 @@ export class LaCrosseViewPlatform implements DynamicPlatformPlugin {
 
   async discoverDevices(initial?: boolean) {
     try {
-      this.log.info('Discovering devices')
+      if (!this.config.disablePollingLogs) {
+        this.log.info('Discovering devices')
+      }
 
       const devices = await this.getDevices()
       const discoveredCacheUUIDs: string[] = []

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -29,6 +29,7 @@ interface LaCrosseViewConfig extends PlatformConfig {
   locationsToExclude: string[]
   fakeGatoEnabled: boolean
   fakeGatoStoragePath?: string
+  disablePollingLogs?: boolean
 }
 
 function generateConfig(config: PlatformConfig): LaCrosseViewConfig {
@@ -53,6 +54,7 @@ function generateConfig(config: PlatformConfig): LaCrosseViewConfig {
     locationsToExclude: config.locationsToExclude || [],
     fakeGatoEnabled: fakeGatoEnabled ? Boolean(fakeGatoEnabled) : false,
     fakeGatoStoragePath: fakeGatoStoragePath ? String(fakeGatoStoragePath) : undefined,
+    disablePollingLogs: config.disablePollingLogs ? Boolean(config.disablePollingLogs) : false,
   }
 }
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -81,7 +81,9 @@ export class Accessory {
 
   async updateDataSensors() {
     try {
-      this.log.info(`[%s] lacrosse.getDeviceStatus("%s")`, this.accessory.displayName, this.accessory.context.device.id)
+      if (!this.platform.config.disablePollingLogs) {
+        this.log.info(`[%s] lacrosse.getDeviceStatus("%s")`, this.accessory.displayName, this.accessory.context.device.id)
+      }
 
       const { humidity, temperature, battery } = await this.lacrosse.getDeviceStatus(this.accessory.context.device.id)
 


### PR DESCRIPTION
Add a configuration to disable polling status logs. A new "disablePollingLogs" variable has been defined, and is configurable in the Plugin Config UI.  Set to "true" in order to disable the polling.